### PR TITLE
Do not use hover state for evaluating if tooltip should be shown

### DIFF
--- a/projects/ngcx-tree/package.json
+++ b/projects/ngcx-tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cluetec/ngcx-tree",
-  "version": "17.1.0",
+  "version": "17.1.1",
   "description": "An angular tree component with drag and drop.",
   "author": "Michael Niedermaier <mn@cluetec.de>",
   "repository": "https://github.com/cluetec/ngcx-tree",

--- a/projects/ngcx-tree/src/lib/ngcx-tree/ngcx-tree.component.scss
+++ b/projects/ngcx-tree/src/lib/ngcx-tree/ngcx-tree.component.scss
@@ -109,7 +109,7 @@
     // background-color: rgba(255, 255, 0, 0.5);
   }
 
-  &:not(:hover) .tooltip {
-    display: none;
+  &.cdk-drop-list-dragging .tooltip {
+    display: block;
   }
 }

--- a/projects/ngcx-tree/styles/_ngcx-tooltip.scss
+++ b/projects/ngcx-tree/styles/_ngcx-tooltip.scss
@@ -1,5 +1,6 @@
 .tree-node-container-drop-zone {
   .tooltip {
+    display: none;
     border: 1px solid lightgrey;
     background: white;
     box-shadow: 3px 0px 10px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
Do not use hover state for evaluating if tooltip should be shown because safari does not trigger hover state while dragging a node