### PR TITLE
Show tooltip on hover too because sometimes cdk does not add cdk-drop-list-dragging class

### DIFF
--- a/projects/ngcx-tree/package.json
+++ b/projects/ngcx-tree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cluetec/ngcx-tree",
-  "version": "17.1.1",
+  "version": "17.1.2",
   "description": "An angular tree component with drag and drop.",
   "author": "Michael Niedermaier <mn@cluetec.de>",
   "repository": "https://github.com/cluetec/ngcx-tree",

--- a/projects/ngcx-tree/src/lib/ngcx-tree/ngcx-tree.component.scss
+++ b/projects/ngcx-tree/src/lib/ngcx-tree/ngcx-tree.component.scss
@@ -109,6 +109,7 @@
     // background-color: rgba(255, 255, 0, 0.5);
   }
 
+  &.cdk-drop-list-receiving:hover .tooltip,
   &.cdk-drop-list-dragging .tooltip {
     display: block;
   }


### PR DESCRIPTION
Show tooltip on hover too because sometimes cdk does not add cdk-drop-list-dragging class
